### PR TITLE
fix: remove default value for payments to force change

### DIFF
--- a/index.html
+++ b/index.html
@@ -207,7 +207,6 @@
                 type="number"
                 min="0"
                 step="1"
-                value="1"
                 placeholder="ex: 1"
                 required
                 onkeyup="
@@ -218,6 +217,7 @@
                 "
               />
             </label>
+            &nbsp;&nbsp;
             <label
               ># of Payments
               <small>superblocks</small>
@@ -226,7 +226,6 @@
                 type="number"
                 min="1"
                 step="1"
-                value="3"
                 placeholder="ex: 3"
                 required
                 onkeyup="
@@ -237,6 +236,7 @@
                 "
               />
             </label>
+            &nbsp;&nbsp;
             <label
               >Payment Amount
               <small>whole DASH</small>
@@ -245,7 +245,6 @@
                 type="number"
                 min="1"
                 step="1"
-                value="1"
                 placeholder="ex: 5"
                 required
                 onkeyup="


### PR DESCRIPTION
This has bit me in the butt twice now where I've accidentally submitted a proposal without setting the payment terms.

These were really just supposed to be there for development anyway.

Gone.